### PR TITLE
types: add JSDoc based TypeScript typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+*.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ build/
 dist/
 docs/
 *.yaml
+*.d.ts

--- a/lib/check-link.js
+++ b/lib/check-link.js
@@ -13,7 +13,7 @@ export const agent = {
  * @typedef {import('got').Response} Response
  *
  * @typedef {object} LivenessResult
- * @property {'invalid' | 'alive' | 'dead' | string} status
+ * @property {'invalid' | 'alive' | 'dead'} status
  * @property {number} [statusCode]
  */
 
@@ -66,16 +66,22 @@ export function checkLink(url, opts = {}) {
           retry: { limit: 0 }
         })
       )
-      .then((res) => ({
-        status: 'alive',
-        statusCode: res.statusCode
-      }))
+      .then(
+        (res) =>
+          /** @type {const} */ ({
+            status: 'alive',
+            statusCode: res.statusCode
+          })
+      )
 
   const fetchGET = () =>
-    got(url, opts).then((res) => ({
-      status: 'alive',
-      statusCode: res.statusCode
-    }))
+    got(url, opts).then(
+      (res) =>
+        /** @type {const} */ ({
+          status: 'alive',
+          statusCode: res.statusCode
+        })
+    )
 
   return fetchHEAD()
     .catch((/** @type {HTTPError} */ err) => {
@@ -86,9 +92,9 @@ export function checkLink(url, opts = {}) {
     })
     .catch((/** @type {Response} */ err) => {
       console.warn('GET error', err)
-      return {
+      return /** @type {const} */ ({
         status: 'dead',
         statusCode: err.statusCode
-      }
+      })
     })
 }

--- a/lib/check-link.js
+++ b/lib/check-link.js
@@ -4,9 +4,18 @@ import https from 'https'
 import { utils } from './utils.js'
 
 export const agent = {
-  http: new http.Agent({ rejectUnauthorized: false }),
+  http: new http.Agent(),
   https: new https.Agent({ rejectUnauthorized: false })
 }
+
+/**
+ * @typedef {import('got').HTTPError} HTTPError
+ * @typedef {import('got').Response} Response
+ *
+ * @typedef {object} LivenessResult
+ * @property {'invalid' | 'alive' | 'dead' | string} status
+ * @property {number} [statusCode]
+ */
 
 /**
  * Checks if a URL is alive (2XX status code).
@@ -15,7 +24,7 @@ export const agent = {
  * @function
  *
  * @param {string} url - URL to test
- * @param {object} [opts] - Optional configuration options passed to got
+ * @param {import('got').OptionsOfTextResponseBody} [opts] - Optional configuration options passed to got
  *
  * @return {Promise<LivenessResult>}
  */
@@ -25,7 +34,7 @@ export function checkLink(url, opts = {}) {
   opts = {
     headers: {
       'user-agent': utils.userAgent,
-      'Upgrade-Insecure-Requests': 1,
+      'Upgrade-Insecure-Requests': '1',
       connection: 'keep-alive',
       accept:
         'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
@@ -69,13 +78,13 @@ export function checkLink(url, opts = {}) {
     }))
 
   return fetchHEAD()
-    .catch((err) => {
+    .catch((/** @type {HTTPError} */ err) => {
       console.warn('HEAD error', err)
       // TODO: if HEAD results in a `got.HTTPError`, are there status codes where
       // we can bypass the GET request?
       return fetchGET()
     })
-    .catch((err) => {
+    .catch((/** @type {Response} */ err) => {
       console.warn('GET error', err)
       return {
         status: 'dead',

--- a/lib/check-links.js
+++ b/lib/check-links.js
@@ -1,11 +1,16 @@
 import pMap from 'p-map'
 import pMemoize from 'p-memoize'
+import ExpiryMap from 'expiry-map'
 
 import { checkLink } from './check-link.js'
 
-const isUrlAlive = pMemoize(checkLink, {
-  maxAge: 60 * 1000
-})
+/** @type {import('expiry-map')<string, import('./check-link.js').LivenessResult>} */
+const cache = new ExpiryMap(60 * 1000)
+const isUrlAlive = pMemoize(checkLink, { cache })
+
+/**
+ * @typedef {{[url: string]: import('./check-link.js').LivenessResult}} LivenessResultMap
+ */
 
 /**
  * Robustly checks an array of URLs for liveness.
@@ -27,14 +32,14 @@ const isUrlAlive = pMemoize(checkLink, {
  * @name checkLinks
  * @function
  *
- * @param {array<string>} urls - Array of urls to test
- * @param {object} [opts] - Optional configuration options (any extra options are passed to [got](https://github.com/sindresorhus/got#options))
- * @param {number} [opts.concurrency=8] - Maximum number of urls to resolve concurrently
+ * @param {Array<string>} urls - Array of urls to test
+ * @param {Omit<import('got').OptionsOfTextResponseBody, 'signal'> & Pick<import('p-map').Options, 'concurrency'>} [opts] - Optional configuration options (any extra options are passed to [got](https://github.com/sindresorhus/got#options))
  *
- * @return {Promise<LivenessResult>}
+ * @return {Promise<LivenessResultMap>}
  */
 export async function checkLinks(urls, opts = {}) {
   const concurrency = opts.concurrency || 8
+  /** @type {LivenessResultMap} */
   const results = {}
 
   await pMap(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,9 +5,23 @@ export const protocolWhitelist = new Set(['https:', 'http:'])
 export const userAgent =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36'
 
+/**
+ * @typedef {object} Options
+ * @property {string} [baseUrl]
+ * @property {unknown} [agent]
+ * @property {import('http').IncomingHttpHeaders} [headers]
+ * @property {unknown} [timeout]
+ */
+
+/**
+ *
+ * @param {string} url
+ * @param {Options} [opts]
+ * @returns
+ */
 export function isValidUrl(url, opts) {
   if (isRelativeUrl(url)) {
-    return !!opts.baseUrl
+    return opts && !!opts.baseUrl
   } else {
     try {
       const parsedUrl = new URL(url)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "type": "module",
   "module": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "exports": {
     "default": "./lib/index.js"
   },
@@ -15,8 +16,9 @@
     "node": ">=14.17"
   },
   "scripts": {
+    "build": "rimraf \"lib/**/*.d.ts\" \"test/**/*.d.ts\" \"*.d.ts\" && tsc && type-coverage",
     "docs": "update-markdown-jsdoc --no-markdown-toc --shallow",
-    "test": "ava -v && prettier --check ."
+    "test": "ava -v && prettier --check . && pnpm build"
   },
   "keywords": [
     "url",
@@ -32,16 +34,27 @@
     "url-check"
   ],
   "dependencies": {
+    "expiry-map": "^2.0.0",
     "got": "^12.5.2",
     "is-relative-url": "^4.0.0",
     "p-map": "^5.5.0",
     "p-memoize": "^7.1.1"
   },
   "devDependencies": {
+    "@types/sinon": "^10.0.13",
     "ava": "^5.0.1",
     "nock": "^13.2.9",
     "prettier": "^2.7.1",
+    "rimraf": "^3.0.2",
     "sinon": "^14.0.2",
+    "type-coverage": "^2.22.0",
+    "typescript": "^4.8.4",
     "update-markdown-jsdoc": "^1.0.6"
+  },
+  "typeCoverage": {
+    "atLeast": 100,
+    "detail": true,
+    "strict": true,
+    "ignoreCatch": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,27 +1,37 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@types/sinon': ^10.0.13
   ava: ^5.0.1
+  expiry-map: ^2.0.0
   got: ^12.5.2
   is-relative-url: ^4.0.0
   nock: ^13.2.9
   p-map: ^5.5.0
   p-memoize: ^7.1.1
   prettier: ^2.7.1
+  rimraf: ^3.0.2
   sinon: ^14.0.2
+  type-coverage: ^2.22.0
+  typescript: ^4.8.4
   update-markdown-jsdoc: ^1.0.6
 
 dependencies:
+  expiry-map: 2.0.0
   got: 12.5.2
   is-relative-url: 4.0.0
   p-map: 5.5.0
   p-memoize: 7.1.1
 
 devDependencies:
+  '@types/sinon': 10.0.13
   ava: 5.0.1
   nock: 13.2.9
   prettier: 2.7.1
+  rimraf: 3.0.2
   sinon: 14.0.2
+  type-coverage: 2.22.0_typescript@4.8.4
+  typescript: 4.8.4
   update-markdown-jsdoc: 1.0.11
 
 packages:
@@ -596,6 +606,16 @@ packages:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
       '@types/node': 18.11.9
+    dev: true
+
+  /@types/sinon/10.0.13:
+    resolution: {integrity: sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==}
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.2
+    dev: true
+
+  /@types/sinonjs__fake-timers/8.1.2:
+    resolution: {integrity: sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==}
     dev: true
 
   /@types/stack-utils/1.0.1:
@@ -1784,6 +1804,7 @@ packages:
 
   /bindings/1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -2839,6 +2860,13 @@ packages:
       - supports-color
     dev: true
 
+  /expiry-map/2.0.0:
+    resolution: {integrity: sha512-K1I5wJe2fiqjyUZf/xhxwTpaopw3F+19DsO7Oggl20+3SVTXDIevVRJav0aBMfposQdkl2E4+gnuOKd3j2X0sA==}
+    engines: {node: '>=8'}
+    dependencies:
+      map-age-cleaner: 0.2.0
+    dev: false
+
   /extend-shallow/2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -2940,6 +2968,7 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -4812,6 +4841,13 @@ packages:
       p-defer: 1.0.0
     dev: true
 
+  /map-age-cleaner/0.2.0:
+    resolution: {integrity: sha512-AvxTC6id0fzSf6OyNBTp1syyCuKO7nOJvHgYlhT0Qkkjvk40zZo+av3ayVgXlxnF/DxEzEfY9mMdd7FHsd+wKQ==}
+    engines: {node: '>=7.6'}
+    dependencies:
+      p-defer: 1.0.0
+    dev: false
+
   /map-cache/0.2.2:
     resolution: {integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==}
     engines: {node: '>=0.10.0'}
@@ -5057,6 +5093,7 @@ packages:
 
   /nan/2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -5333,7 +5370,6 @@ packages:
   /p-defer/1.0.0:
     resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
     engines: {node: '>=4'}
-    dev: true
 
   /p-each-series/1.0.0:
     resolution: {integrity: sha512-J/e9xiZZQNrt+958FFzJ+auItsBGq+UrQ7nE89AUP7UOTtjHnkISANXLdayhVzh538UnLMCSlf13lFfRIAKQOA==}
@@ -7049,6 +7085,24 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: true
 
+  /tslib/1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
+
+  /tslib/2.4.1:
+    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+    dev: true
+
+  /tsutils/3.21.0_typescript@4.8.4:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.8.4
+    dev: true
+
   /tunnel-agent/0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
     dependencies:
@@ -7064,6 +7118,29 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.1.2
+    dev: true
+
+  /type-coverage-core/2.22.0_typescript@4.8.4:
+    resolution: {integrity: sha512-j2wjwOTeKc/G6RUrgVsBYuDbum2GnJ/pCQ6/DlMvgs1QBXEqZxI9N6okUSFc14veQBzr01gG0cwmdyagKdf3Sg==}
+    peerDependencies:
+      typescript: 2 || 3 || 4
+    dependencies:
+      fast-glob: 3.2.12
+      minimatch: 3.1.2
+      normalize-path: 3.0.0
+      tslib: 2.4.1
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
+    dev: true
+
+  /type-coverage/2.22.0_typescript@4.8.4:
+    resolution: {integrity: sha512-wgM1yH4J5gAszojftiozxb6HSOvoCqYQLmIS5Ybo4HpBtr9BrVgK5duj4e3tkc28Xg6VA2WPB8GFC+oJw352oQ==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.7
+      type-coverage-core: 2.22.0_typescript@4.8.4
+    transitivePeerDependencies:
+      - typescript
     dev: true
 
   /type-detect/4.0.8:
@@ -7097,6 +7174,12 @@ packages:
 
   /typedarray/0.0.7:
     resolution: {integrity: sha512-ueeb9YybpjhivjbHP2LdFDAjbS948fGEPj+ACAMs4xCMmh72OCOMQWBQKlaN4ZNQ04yfLSDLSx1tGRIoWimObQ==}
+    dev: true
+
+  /typescript/4.8.4:
+    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
     dev: true
 
   /unbox-primitive/1.0.2:

--- a/test/check-link.test.js
+++ b/test/check-link.test.js
@@ -5,6 +5,7 @@ import { checkLink, utils } from '../lib/index.js'
 
 test.serial('check-links default options', async (t) => {
   const stub = sinon.stub(utils, 'isValidUrl').callsFake((url, opts) => {
+    // @ts-expect-error options will always be passed here
     const { agent, ...rest } = opts
 
     t.is(url, 'invalid')
@@ -12,7 +13,7 @@ test.serial('check-links default options', async (t) => {
     t.deepEqual(rest, {
       headers: {
         'user-agent': utils.userAgent,
-        'Upgrade-Insecure-Requests': 1,
+        'Upgrade-Insecure-Requests': '1',
         connection: 'keep-alive',
         accept:
           'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
@@ -22,6 +23,8 @@ test.serial('check-links default options', async (t) => {
       },
       timeout: { request: 30000 }
     })
+
+    return true
   })
 
   await checkLink('invalid')
@@ -31,12 +34,13 @@ test.serial('check-links default options', async (t) => {
 
 test.serial('check-links overriding got options', async (t) => {
   const stub = sinon.stub(utils, 'isValidUrl').callsFake((url, opts) => {
+    // @ts-expect-error options will always be passed here
     const { agent, ...rest } = opts
 
     t.deepEqual(rest, {
       headers: {
         'user-agent': utils.userAgent,
-        'Upgrade-Insecure-Requests': 1,
+        'Upgrade-Insecure-Requests': '1',
         connection: 'keep-alive',
         accept:
           'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
@@ -48,6 +52,8 @@ test.serial('check-links overriding got options', async (t) => {
       timeout: { request: 10000 },
       retry: { limit: 5 }
     })
+
+    return true
   })
 
   await checkLink('invalid', {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "include": ["lib/**/*.js", "test/**/*.js", "*.js"],
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "strict": true
+  }
+}


### PR DESCRIPTION
Changes:

* Uses JSDoc comments to generate TypeScript typings
* Fixes usage of `http.Agent()` removing unsupported options (detected by typescript)
* Fixes usage of `pMemoize` which has replaced `maxAge` option, with using `ExpiryMap` as the `cache` option (detected by typescript)

Goals:
* Keep changes to existing code to minimum needed, while also achieving: 100% type coverage and passing type checks
* Use plain JavaScript, so code from GitHub can be used directly, without needing to compile. Typings can be generated for TypeScript/npm publishing, but are optional