### PR TITLE
build: include all files in the lib folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "Travis Fischer <travis@transitivebullsh.it>",
   "license": "MIT",
   "type": "module",
+  "files": [
+    "lib/"
+  ],
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {


### PR DESCRIPTION
resolve issue where `.d.ts` files in the `lib/` folder are ignored when releasing to the npm registry.
https://unpkg.com/browse/check-links@2.1.1/lib/

This resolve it by overriding the ignore file, and giving an explicit include https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files